### PR TITLE
added configuration file for installing the package using a conda environment

### DIFF
--- a/deps.yml
+++ b/deps.yml
@@ -1,0 +1,12 @@
+name: condatitanlib
+channels:
+- conda-forge
+dependencies:
+- boost
+- gsl
+- swig
+- cmake
+- libblas
+- doxygen
+- numpy
+- python=3.10.4


### PR DESCRIPTION
Note: Further explanations about how installing titanlib within a conda environment will be written in the wiki.